### PR TITLE
Logging stack trace of an exception

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/command/AllureCommand.java
+++ b/src/main/java/ru/yandex/qatools/allure/command/AllureCommand.java
@@ -8,6 +8,8 @@ import org.apache.log4j.Logger;
 import ru.yandex.qatools.allure.AllureCLI;
 import ru.yandex.qatools.allure.AllureConfig;
 
+import java.text.MessageFormat;
+
 /**
  * eroshenkoam
  * 11/08/14
@@ -35,8 +37,7 @@ public abstract class AllureCommand implements Runnable {
         try {
             runUnsafe();
         } catch (Exception e) {
-            getLogger().info(e.getMessage());
-            getLogger().debug(e);
+            getLogger().error(MessageFormat.format("Command {0} aborted due to exception", getClass().getName()), e);
         }
     }
 


### PR DESCRIPTION
Hi, here is a change to exception logging in AllureCommand, so that stack trace is included in the output. Related to issue https://github.com/allure-framework/allure-cli/issues/33

Before:
```
java.lang.NullPointerException
ru.yandex.qatools.allure.report.AllureReportBuilderException: java.lang.NullPointerException'
```
After:
```
Command ru.yandex.qatools.allure.command.ReportGenerate aborted due to exception
ru.yandex.qatools.allure.report.AllureReportBuilderException: java.lang.NullPointerException
	at ru.yandex.qatools.allure.report.AllureReportBuilder.processResults(AllureReportBuilder.java:133)
	at ru.yandex.qatools.allure.command.ReportGenerate.runUnsafe(ReportGenerate.java:47)
	at ru.yandex.qatools.allure.command.AllureCommand.run(AllureCommand.java:38)
	at ru.yandex.qatools.allure.AllureCLI.main(AllureCLI.java:32)
Caused by: java.lang.NullPointerException
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:361)
	at ru.yandex.qatools.clay.Aether.resolveWithTransitives(Aether.java:177)
	at ru.yandex.qatools.clay.Aether.resolve(Aether.java:131)
	at ru.yandex.qatools.clay.Aether.resolve(Aether.java:109)
	at ru.yandex.qatools.allure.report.AllureReportBuilder.processResults(AllureReportBuilder.java:127)
	... 3 more'
 ```
